### PR TITLE
Added shortened consumer key to work with D2L & Canvas

### DIFF
--- a/qmlti/src/lti/consumer.php
+++ b/qmlti/src/lti/consumer.php
@@ -80,7 +80,11 @@ require_once('../resources/lib.php');
     unset($_SESSION['consumer_key']);
   }
   if (!isset($_SESSION['consumer_key'])) {
-    $_SESSION['consumer_key'] = create_guid();
+    if (isset($_SESSION['reduced_checksum'])) {
+      $_SESSION['consumer_key'] = create_shortened_guid();
+    } else {
+      $_SESSION['consumer_key'] = create_guid();
+    }
     $_SESSION['secret'] = getRandomString(32);
   }
   if (!isset($consumer->secret)) {

--- a/qmlti/src/lti/index.php
+++ b/qmlti/src/lti/index.php
@@ -59,6 +59,9 @@ require_once('../resources/lib.php');
 
   if (strtoupper($_SERVER['REQUEST_METHOD']) == 'POST') {
     $action = $_POST['action'];
+    if (isset($_POST['reduced_checksum'])) {
+      $_SESSION['reduced_checksum'] = 1;
+    }
     if (isset($_POST['debug'])) {
       $customer['customer_id'] = $_POST['customer_id'];
     } else {
@@ -113,7 +116,10 @@ require_once('../resources/lib.php');
 
   $script = <<< EOD
 <script type="text/javascript">
-<!--
+$(document).ready(function(){
+  $('[data-toggle="tooltip"]').tooltip();
+});
+
 if (!String.prototype.trim) {
  String.prototype.trim = function() {
   return this.replace(/^\s+|\s+$/g,'');
@@ -174,7 +180,6 @@ function checkForm() {
   }
   return ok;
 }
-// -->
 </script>
 EOD;
 
@@ -229,6 +234,17 @@ EOD;
           </div>
           <div class="col2">
             <input type="checkbox" id="debug" name="debug" value="1" />
+          </div>
+        </div>
+        <div class="row">
+          <div class="col1">
+              Use reduced checksum
+            <a href="#" data-toggle="tooltip" title="Some learning management systems use a version of the LTI that requires the checksum to be reduced. Enabling this feature could lower the security of your LTI connector.">
+              <span class="glyphicon glyphicon-question-sign"></span>
+            </a>
+          </div>
+          <div class="col2">
+            <input type="checkbox" id="reduced_checksum" name="reduced_checksum" value="1" />
           </div>
         </div>
         <br><br>

--- a/qmlti/src/lti/index.php
+++ b/qmlti/src/lti/index.php
@@ -238,8 +238,8 @@ EOD;
         </div>
         <div class="row">
           <div class="col1">
-              Use reduced checksum
-            <a href="#" data-toggle="tooltip" title="Some learning management systems use a version of the LTI that requires the checksum to be reduced. Enabling this feature could lower the security of your LTI connector.">
+              Use reduced consumer key
+            <a href="#" data-toggle="tooltip" title="Some learning management systems use a version of the LTI that requires the consumer key to be reduced. Enabling this feature could lower the security of your LTI connector.">
               <span class="glyphicon glyphicon-question-sign"></span>
             </a>
           </div>

--- a/qmlti/src/lti/view/staff.php
+++ b/qmlti/src/lti/view/staff.php
@@ -9,7 +9,9 @@
         <div id="PageContent" class="block-color">
         <div id="body" class="container-fluid">
         <p>
-          <a class="btn btn-default btn-grey" href="<?php echo $return_url; ?>">Back to Course</button></a>
+          <?php if (!empty($return_url)) { ?>
+            <a class="btn btn-default btn-grey" href="<?php echo $return_url; ?>">Back to Course</a>
+          <?php } ?>
           <a class="btn btn-default btn-grey" href="<?php echo $em_url; ?>" target="_blank" />Log into Questionmark Portal</a>
           <a class="btn btn-default btn-grey" href="staff_results.php" />View Assessment Results</a>
         </p>

--- a/qmlti/src/lti/view/staff_results.php
+++ b/qmlti/src/lti/view/staff_results.php
@@ -9,7 +9,9 @@
         <div id="PageContent" class="block-color">
         <div id="body" class="container-fluid">
         <p>
-        <a class="btn btn-default btn-grey" href="<?php echo $return_url; ?>">Back to Course</button></a>
+        <?php if (!empty($return_url)) { ?>
+          <a class="btn btn-default btn-grey" href="<?php echo $return_url; ?>">Back to Course</a>
+        <?php } ?>
         <a class="btn btn-default btn-grey" href="<?php echo $em_url; ?>" target="_blank" />Log into Questionmark Portal</a>
         <a class="btn btn-default btn-grey" href="staff.php" />Back to Assessment Configuration Page</a>
         </p>

--- a/qmlti/src/lti/view/student_nav.php
+++ b/qmlti/src/lti/view/student_nav.php
@@ -9,7 +9,9 @@
         <div id="PageContent" class="block-color">
           <div class="container-fluid">
             <p>
-              <button type="button" class="btn btn-default btn-grey no-margin" onclick="location.href='<?php echo $return_url; ?>'">Back to Course</button>
+              <?php if (!empty($return_url)) { ?>
+                <a class="btn btn-default btn-grey" href="<?php echo $return_url; ?>">Back to Course</button></a>
+              <?php } ?>
             </p>
           </div>
           <div id="body" class="container-fluid" style="padding: 0px">

--- a/qmlti/src/resources/LTI_Data_Connector_qmp.php
+++ b/qmlti/src/resources/LTI_Data_Connector_qmp.php
@@ -719,7 +719,6 @@ class LTI_Data_Connector_QMP extends LTI_Data_Connector {
       $row = $query->fetch();
       $result_id = $row['result_id'];
     } else {
-      error_log(print_r($query->errorInfo(), true));
       return FALSE;
     }
     return $result_id;

--- a/qmlti/src/resources/LTI_Data_Connector_qmp.php
+++ b/qmlti/src/resources/LTI_Data_Connector_qmp.php
@@ -89,7 +89,7 @@ class LTI_Data_Connector_QMP extends LTI_Data_Connector {
 /*
  *    Save the tool consumer to the database
  */
-  public function Tool_Consumer_save($consumer) {
+  public function Tool_Consumer_save($consumer, $changeConsumerName = TRUE) {
     $ok = TRUE;
     if (defined('CONSUMER_KEY')) {
       $consumer->updated = time();
@@ -116,19 +116,34 @@ class LTI_Data_Connector_QMP extends LTI_Data_Connector {
         $query->bindValue('created', $now, PDO::PARAM_STR);
         $query->bindValue('updated', $now, PDO::PARAM_STR);
       } else {
-        $sql = 'UPDATE ' . $this->dbTableNamePrefix . LTI_Data_Connector::CONSUMER_TABLE_NAME . ' ' .
+        if ($changeConsumerName) {
+          $sql = 'UPDATE ' . $this->dbTableNamePrefix . LTI_Data_Connector::CONSUMER_TABLE_NAME . ' ' .
                'SET secret = :secret, ' .
                'consumer_name = :consumer_name, customer_id = :customer_id, username_prefix = :username_prefix, ' .
                'last_access = :last_access, updated = :updated ' .
                'WHERE consumer_key = :key';
-        $query = $this->db->prepare($sql);
-        $query->bindValue('key', $key, PDO::PARAM_STR);
-        $query->bindValue('secret', $consumer->secret, PDO::PARAM_STR);
-        $query->bindValue('consumer_name', $consumer->consumer_name, PDO::PARAM_STR);
-        $query->bindValue('customer_id', $consumer->custom['customer_id'], PDO::PARAM_STR);
-        $query->bindValue('username_prefix', $consumer->custom['username_prefix'], PDO::PARAM_STR);
-        $query->bindValue('last_access', $last, PDO::PARAM_STR);
-        $query->bindValue('updated', $now, PDO::PARAM_STR);
+          $query = $this->db->prepare($sql);
+          $query->bindValue('key', $key, PDO::PARAM_STR);
+          $query->bindValue('secret', $consumer->secret, PDO::PARAM_STR);
+          $query->bindValue('consumer_name', $consumer->consumer_name, PDO::PARAM_STR);
+          $query->bindValue('customer_id', $consumer->custom['customer_id'], PDO::PARAM_STR);
+          $query->bindValue('username_prefix', $consumer->custom['username_prefix'], PDO::PARAM_STR);
+          $query->bindValue('last_access', $last, PDO::PARAM_STR);
+          $query->bindValue('updated', $now, PDO::PARAM_STR);
+        } else {
+          $sql = 'UPDATE ' . $this->dbTableNamePrefix . LTI_Data_Connector::CONSUMER_TABLE_NAME . ' ' .
+               'SET secret = :secret, ' .
+               'customer_id = :customer_id, username_prefix = :username_prefix, ' .
+               'last_access = :last_access, updated = :updated ' .
+               'WHERE consumer_key = :key';
+          $query = $this->db->prepare($sql);
+          $query->bindValue('key', $key, PDO::PARAM_STR);
+          $query->bindValue('secret', $consumer->secret, PDO::PARAM_STR);
+          $query->bindValue('customer_id', $consumer->custom['customer_id'], PDO::PARAM_STR);
+          $query->bindValue('username_prefix', $consumer->custom['username_prefix'], PDO::PARAM_STR);
+          $query->bindValue('last_access', $last, PDO::PARAM_STR);
+          $query->bindValue('updated', $now, PDO::PARAM_STR);
+        }
       }
       $ok = $query->execute();
       if ($ok) {
@@ -719,6 +734,7 @@ class LTI_Data_Connector_QMP extends LTI_Data_Connector {
       $row = $query->fetch();
       $result_id = $row['result_id'];
     } else {
+      error_log(print_r($query->errorInfo(), true));
       return FALSE;
     }
     return $result_id;

--- a/qmlti/src/resources/LTI_Tool_Provider.php
+++ b/qmlti/src/resources/LTI_Tool_Provider.php
@@ -628,7 +628,7 @@ class LTI_Tool_Provider {
     }
     # Persist changes to consumer
     if ($doSaveConsumer) {
-      $this->consumer->save();
+      $this->consumer->save(false);
     }
     if ($this->isOK && isset($this->resource_link)) {
     # Check if a share arrangement is in place for this resource link
@@ -850,8 +850,8 @@ class LTI_Tool_Consumer {
  *
  * @return boolean True if the object was successfully saved
  */
-  public function save() {
-    return $this->data_connector->Tool_Consumer_save($this);
+  public function save($changeConsumerName = TRUE) {
+    return $this->data_connector->Tool_Consumer_save($this, $changeConsumerName);
   }
 
 /**

--- a/qmlti/src/resources/OAuth.php
+++ b/qmlti/src/resources/OAuth.php
@@ -1,6 +1,6 @@
 <?php
 
-/* 
+/*
  * Generic exception class
  */
 class OAuthException extends Exception {}
@@ -104,9 +104,9 @@ abstract class OAuthSignatureMethod {
 }
 
 /**
- * The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104] 
- * where the Signature Base String is the text and the key is the concatenated values (each first 
- * encoded per Parameter Encoding) of the Consumer Secret and Token Secret, separated by an '&' 
+ * The HMAC-SHA1 signature method uses the HMAC-SHA1 signature algorithm as defined in [RFC2104]
+ * where the Signature Base String is the text and the key is the concatenated values (each first
+ * encoded per Parameter Encoding) of the Consumer Secret and Token Secret, separated by an '&'
  * character (ASCII code 38) even if empty.
  *   - Chapter 9.2 ("HMAC-SHA1")
  */
@@ -132,7 +132,7 @@ class OAuthSignatureMethod_HMAC_SHA1 extends OAuthSignatureMethod {
 }
 
 /**
- * The PLAINTEXT method does not provide any security protection and SHOULD only be used 
+ * The PLAINTEXT method does not provide any security protection and SHOULD only be used
  * over a secure channel such as HTTPS. It does not use the Signature Base String.
  *   - Chapter 9.4 ("PLAINTEXT")
  */
@@ -142,8 +142,8 @@ class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod {
   }
 
   /**
-   * oauth_signature is set to the concatenated encoded values of the Consumer Secret and 
-   * Token Secret, separated by a '&' character (ASCII code 38), even if either secret is 
+   * oauth_signature is set to the concatenated encoded values of the Consumer Secret and
+   * Token Secret, separated by a '&' character (ASCII code 38), even if either secret is
    * empty. The result MUST be encoded again.
    *   - Chapter 9.4.1 ("Generating Signatures")
    *
@@ -165,10 +165,10 @@ class OAuthSignatureMethod_PLAINTEXT extends OAuthSignatureMethod {
 }
 
 /**
- * The RSA-SHA1 signature method uses the RSASSA-PKCS1-v1_5 signature algorithm as defined in 
- * [RFC3447] section 8.2 (more simply known as PKCS#1), using SHA-1 as the hash function for 
- * EMSA-PKCS1-v1_5. It is assumed that the Consumer has provided its RSA public key in a 
- * verified way to the Service Provider, in a manner which is beyond the scope of this 
+ * The RSA-SHA1 signature method uses the RSASSA-PKCS1-v1_5 signature algorithm as defined in
+ * [RFC3447] section 8.2 (more simply known as PKCS#1), using SHA-1 as the hash function for
+ * EMSA-PKCS1-v1_5. It is assumed that the Consumer has provided its RSA public key in a
+ * verified way to the Service Provider, in a manner which is beyond the scope of this
  * specification.
  *   - Chapter 9.3 ("RSA-SHA1")
  */
@@ -569,7 +569,7 @@ class OAuthServer {
   private function get_version(&$request) {
     $version = $request->get_parameter("oauth_version");
     if (!$version) {
-      // Service Providers MUST assume the protocol version to be 1.0 if this parameter is not present. 
+      // Service Providers MUST assume the protocol version to be 1.0 if this parameter is not present.
       // Chapter 7.0 ("Accessing Protected Ressources")
       $version = '1.0';
     }
@@ -583,7 +583,7 @@ class OAuthServer {
    * figure out the signature with some defaults
    */
   private function get_signature_method($request) {
-    $signature_method = $request instanceof OAuthRequest 
+    $signature_method = $request instanceof OAuthRequest
         ? $request->get_parameter("oauth_signature_method")
         : NULL;
 
@@ -608,7 +608,7 @@ class OAuthServer {
    * try to find the consumer for the provided request's consumer key
    */
   private function get_consumer($request) {
-    $consumer_key = $request instanceof OAuthRequest 
+    $consumer_key = $request instanceof OAuthRequest
         ? $request->get_parameter("oauth_consumer_key")
         : NULL;
 
@@ -660,6 +660,7 @@ class OAuthServer {
     $signature_method = $this->get_signature_method($request);
 
     $signature = $request->get_parameter('oauth_signature');
+
     $valid_sig = $signature_method->check_signature(
       $request,
       $consumer,
@@ -680,7 +681,7 @@ class OAuthServer {
       throw new OAuthException(
         'Missing timestamp parameter. The parameter is required'
       );
-    
+
     // verify that timestamp is recentish
     $now = time();
     if (abs($now - $timestamp) > $this->timestamp_threshold) {

--- a/qmlti/src/resources/lib.php
+++ b/qmlti/src/resources/lib.php
@@ -1463,4 +1463,15 @@ EOD;
     }
   }
 
+/*
+ * Generate a shortened GUID, required for some LMS such as D2L
+ *
+ *   returns the generated GUID
+ */
+  function create_shortened_guid() {
+    $md5 = strtoupper(md5(uniqid(rand(), true)));
+    $guid = '{' . substr($md5, 0, 8) . '-' . substr($md5, 8, 8) . '}';
+    return $guid;
+  }
+
 ?>


### PR DESCRIPTION
# Problem

D2L was getting OAuth issues when attempting to sign on as an instructor or a student, which meant that they were not able to access LTI.

# Resolution

3 steps:

1. Added a truncated consumer key option to toggle on for D2L OAuth
2. Have to reduce secret length (can be user customised - no code required)
3. Extended nonce length in DB to 50 characters
